### PR TITLE
Fix a few typos

### DIFF
--- a/ause-coc.rst
+++ b/ause-coc.rst
@@ -7,7 +7,7 @@ and certain appropriate common sense rules apply to working on it.
 Acceptable Use Guidelines
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The Satori resource is intended for reasearch associated with MIT projects or collaborations around
+The Satori resource is intended for research associated with MIT projects or collaborations around
 MIT research projects. That can cover a lot of things, but all account holders are expected
 to use judgement and apply common sense to their use of the system. The system is not
 to be used to support commercial activities or for non-MIT related activities. It is not

--- a/satori-ai-frameworks.rst
+++ b/satori-ai-frameworks.rst
@@ -81,7 +81,7 @@ following command:
    conda config --prepend channels \
    https://public.dhe.ibm.com/ibmdl/export/pub/software/server/ibm-ai/conda/
 
-Add, the MIT Open-CE channel to the conda configuration by running the
+Add the MIT Open-CE channel to the conda configuration by running the
 following command:
 
 .. code:: bash

--- a/satori-basics.rst
+++ b/satori-basics.rst
@@ -6,7 +6,7 @@ What is Satori?
 
 Satori is a GPU dense, high-performance Power 9 system developed as a collaboration between MIT and IBM.
 It has 64 1TB memory Power 9 nodes. Each node hosts four NVidia V100 32GB memory GPU cards. Within a 
-node GPUs are linked by an NVLink2 network thst supports nearly to 200GB/s bi-directional transfer
+node GPUs are linked by an NVLink2 network that supports nearly 200GB/s bi-directional transfer
 between GPUs. A 100Gb/s Infiniband network with microsecond user space latency connects the cluster 
 nodes togehter. 
 
@@ -19,7 +19,7 @@ How can I get an account?
      starter account is provided somewhat limited access by default. Once a starter account has been created research 
      group leads may request an account be added to one or more projects that can provide larger scale access.  
    
-**Satori is currently in a beta test phase**. Access requires active MIT Kerberos credentials (available to all students, employees and sponsored guest accounts https://ist.mit.edu/guest-accounts ). To have your kereberos account activated on Satori during the beta test phase please contact with Chris Hill ( cnh@mit.edu ) or John Cohn ( johncohn@us.ibm.com ). 
+**Satori is currently in a beta test phase**. Access requires active MIT Kerberos credentials (available to all students, employees and sponsored guest accounts https://ist.mit.edu/guest-accounts ). To have your kereberos account activated on Satori during the beta test phase contact Chris Hill ( cnh@mit.edu ) or John Cohn ( johncohn@us.ibm.com ). 
 
 Once beta testing is complete, anyone with active MIT Kerberos credentials (i.e. all students, employees and sponsored 
 guest account https://ist.mit.edu/guest-accounts ) will be able to connect to Satori via a portal and a 

--- a/satori-getting-help.rst
+++ b/satori-getting-help.rst
@@ -6,18 +6,18 @@ Email help
 
 If you need help with anything , please email satori-support@techsquare.com . Tech support
 is mostly normal business hours, so responses are usually quicker during regular work hours. 
-Response times during the night and over weekend and holidays (or when ten is a lot going on!)
+Response times during the night and over weekend and holidays (or when there is a lot going on!)
 can be slower.  
 
-Tech technical support team are familiar with some aspects of applications software and are
-always willing to help. For some things though, like trouble shooting advanced AI workflows, it
+The technical support team are familiar with some aspects of applications software and are
+always willing to help. For some things though, like troubleshooting advanced AI workflows, it
 can be good to reach out to other people using the system as they may have useful advice/tricks. 
-The Satori slack channel is available for connecting everyone on Satori in a more free form way.
+The Satori slack channel is available for connecting everyone on Satori in a more free-form way.
 
 Slack
 ^^^^^
 
-A Slack channel for advice, discussion, advance problem solving and more is available to all Satorians.
+A Slack channel for advice, discussion, advanced problem solving and more is available to all Satorians.
 You can connect to the channel `here <https://mit-satori.slack.com/>`_ . To request an invite to
 te Slack channel follow this `link <https://join.slack.com/t/mit-satori/shared_invite/enQtOTE2Mjk2NTc3MTI0LWNmZTAwMGFlM2NlZWMyZjUwOGExMTg1Mjg2ZmUzODIxMzM5YzkzNTE0NmJhZTc2NzhlZTExZmU3MWY5ZWNjZWQ>`_ . 
 
@@ -34,7 +34,5 @@ Tips and Tricks
 ^^^^^^^^^^^^^^^
 
 There is a Tips and Tricks section in the Satori documentation web pages. That can be a useful place to find out 
-specifc weird commands or environment variables that have proved useful. If you have material to contribute their, please
-feel free to add things via Git. 
-
-
+specific weird commands or environment variables that have proved useful. If you have material to contribute there, please
+feel free to add things via Git.

--- a/satori-large-model-support.rst
+++ b/satori-large-model-support.rst
@@ -1,8 +1,8 @@
 IBM Large Model Support (LMS)
 -----------------------------
 
-Allow seamlessly moves layers of a model between the GPU and CPU to
-overcome GPU memory limits allows training of:
+LMS seamlessly moves layers of a model between the GPU and CPU to
+overcome GPU memory limits. This allows training of:
 
 -  Deeper models
 -  Higher resolution data

--- a/satori-ssh.rst
+++ b/satori-ssh.rst
@@ -80,10 +80,10 @@ of this document that can help show how to get started.
 
 As general rules:
 
--  satori-login-001.mit.edu - shuld be used for submiting training jobs
+-  satori-login-001.mit.edu - should be used for submiting training jobs
    and related activities
--  satori-login-002.mit.edu - shuld be used for transfering large
-   files/datasets and compiling software requireing nvcc, gcc, XL
+-  satori-login-002.mit.edu - should be used for transfering large
+   files/datasets and compiling software requiring nvcc, gcc, XL
    compiler etc
 -  if one login-node will not be available try the second one
 -  don’t run large computations on the login nodes

--- a/satori-workload-manager-using-lsf.rst
+++ b/satori-workload-manager-using-lsf.rst
@@ -31,7 +31,15 @@ In general, the process for running a batch job is to:
 A Note on Exclusivity
 ^^^^^^^^^^^^^^^^^^^^^
 
-To make best use of Satori's GPU resource  default job submissiosn are not exclusive. That means that unless you ask otherwise, the GPUs on the node(s) you are assigned may already be in use by another user. That means if you request a node  with 2GPU's  the 2 other GPUs on that node may be engaged by anohther job. This allows us to more efficently allocate all of the GPU resources. This may require some additional checkign to make sure you can uniquly use  all of the GPU's on a machine. If you're in doubt, you can request the node to be 'exclusive' . See below on how to request exclusive access  in an interactive and batch situation. 
+To make best use of Satori's GPU resource  default job submissions are not
+exclusive. That means that unless you ask otherwise, the GPUs on the node(s)
+you are assigned may already be in use by another user. That means if you
+request a node  with 2GPU's  the 2 other GPUs on that node may be engaged by
+another job. This allows us to more efficently allocate all of the GPU
+resources. This may require some additional checking to make sure you can
+uniquely use  all of the GPU's on a machine. If you're in doubt, you can
+request the node to be 'exclusive' . See below on how to request exclusive
+access  in an interactive and batch situation. 
 
 Interactive Jobs
 ^^^^^^^^^^^^^^^^

--- a/satori-workload-manager-using-slurm.rst
+++ b/satori-workload-manager-using-slurm.rst
@@ -29,7 +29,15 @@ In general, the process for running a batch job is to:
 A Note on Exclusivity
 ^^^^^^^^^^^^^^^^^^^^^
 
-To make best use of Satori's GPU resource  default job submissiosn are not exclusive. That means that unless you ask otherwise, the GPUs on the node(s) you are assigned may already be in use by another user. That means if you request a node  with 2GPU's  the 2 other GPUs on that node may be engaged by anohther job. This allows us to more efficently allocate all of the GPU resources. This may require some additional checkign to make sure you can uniquly use  all of the GPU's on a machine. If you're in doubt, you can request the node to be 'exclusive' . See below on how to request exclusive access  in an interactive and batch situation. 
+To make best use of Satori's GPU resource  default job submissiosn are not
+exclusive. That means that unless you ask otherwise, the GPUs on the node(s)
+you are assigned may already be in use by another user. That means if you
+request a node  with 2GPU's  the 2 other GPUs on that node may be engaged by
+another job. This allows us to more efficently allocate all of the GPU
+resources. This may require some additional checking to make sure you can
+uniquely use  all of the GPU's on a machine. If you're in doubt, you can request
+the node to be 'exclusive' . See below on how to request exclusive access  in
+an interactive and batch situation. 
 
 Interactive Jobs
 ^^^^^^^^^^^^^^^^
@@ -238,11 +246,22 @@ queued state, and will change to eligible-to-run at the appropriate time.
 
 Queue Policies
 ~~~~~~~~~~~~~~
-Account holders who are comfortable with basic practices of how to use the system productively (understanding basic Linux commands, learning interactive and batch scheduling techniques, developing 
-basic strategies for managing large numbers of files etc... ) are able to access higher level queues on 
-the system. These can be useful for urgent time constraints such as paper deadlines and for more involved workflows. To request acccess to the priority queue first make sure you are comfortable with the technical and social norms of using a shared system. Then please email support-satori@techsquare.com and indicate that you would like to access higher level queue features. 
+Account holders who are comfortable with basic practices of how to use the
+system productively (understanding basic Linux commands, learning interactive
+and batch scheduling techniques, developing basic strategies for managing large
+numbers of files etc... ) are able to access higher level queues on the system.
+These can be useful for urgent time constraints such as paper deadlines and for
+more involved workflows. To request acccess to the priority queue first make
+sure you are comfortable with the technical and social norms of using a shared
+system. Then please email support-satori@techsquare.com and indicate that you
+would like to access higher level queue features. 
 
-A set higher level queues has initially been set up in two configureations, 1 Node with 4 GPUs and 2 Nodes with 8 GPU's. Job run  length will be capped at 24 hours so please use checkpointing. There will be a limit of 2 parallel jobs per user running during peak times. If these queue setting do not meet your project goals, please email support-satori@techsquare.com with your needed requirments and we will consider them. 
+A set higher level queues has initially been set up in two configurations, 1
+Node with 4 GPUs and 2 Nodes with 8 GPU's. Job run  length will be capped at 24
+hours so please use checkpointing. There will be a limit of 2 parallel jobs per
+user running during peak times. If these queue settings do not meet your project
+goals, please email support-satori@techsquare.com with your needed requirments
+and we will consider them. 
 
 Running jobs in series
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/tips-and-tricks/sys_queries/index.rst
+++ b/tips-and-tricks/sys_queries/index.rst
@@ -60,7 +60,7 @@ architecture, model name, sockets, cores per socket, threads per core, min/max C
 
    lscpu
       
-WHow much RAM is there on my nodes?
+How much RAM is there on my nodes?
 ===================================
 
 The amount of RAM that is expected to be available on a system is summarized elsewhere. The command to interrogate a node for the total available memory is


### PR DESCRIPTION
First of all, thanks go to whoever put the documentation for Satori together as it's made getting started fairly easy.

So, I just found a few typos in the docs and would like to submit them. There were a few places where the lines in the text files were really long and I was already making an edit, so I just did vim's 'gq' on them to align them to 80 columns. Where those changes have been made, a typo has been fixed.